### PR TITLE
Makes message_identification freely configurable

### DIFF
--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -59,6 +59,13 @@ module SEPA
       end
     end
 
+    attr_writer :message_identification # Set unique identifer for the message
+
+    # Unique identifer for the whole message
+    def message_identification
+      @message_identification ||= "SEPA-KING/#{Time.now.to_i}"
+    end
+
   private
     # @return {Hash<Symbol=>String>} xml schema information used in output xml
     def xml_schema(schema_name)
@@ -77,11 +84,6 @@ module SEPA
           builder.Nm(account.name)
         end
       end
-    end
-
-    # Unique identifer for the whole message
-    def message_identification
-      @message_identification ||= "SEPA-KING/#{Time.now.to_i}"
     end
 
     # Unique and consecutive identifier (used for the <PmntInf> blocks)

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -41,4 +41,17 @@ describe SEPA::Message do
       subject.should have(1).error_on(:transactions)
     end
   end
+
+  describe :message_identification do
+    subject { DummyMessage.new }
+
+    it 'should have a reader method' do
+      subject.message_identification.should match(/SEPA-KING\/[0-9]+/)
+    end
+
+    it 'should have a writer method' do
+      subject.message_identification = "MY_MESSAGE_ID/#{Time.now.to_i}"
+      subject.message_identification.should match(/MY_MESSAGE_ID/)
+    end
+  end
 end


### PR DESCRIPTION
If the id has not been set, the old SEPA-KING/\d+ is still used.
