### PR TITLE
Fixed bug in BIC validation

### DIFF
--- a/lib/sepa_king/validator.rb
+++ b/lib/sepa_king/validator.rb
@@ -11,7 +11,7 @@ module SEPA
   class BICValidator < ActiveModel::Validator
     def validate(record)
       if record.bic
-        unless record.bic.to_s.match /[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}/
+        unless record.bic.to_s.match /^[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}$/
           record.errors.add(:bic, :invalid)
         end
       end

--- a/spec/direct_debit_transaction_spec.rb
+++ b/spec/direct_debit_transaction_spec.rb
@@ -55,4 +55,14 @@ describe SEPA::DirectDebitTransaction do
       SEPA::DirectDebitTransaction.should_not accept(nil, '', 'X' * 36, 'ABC 123', '#/*', 'Ümläüt', for: :mandate_id)
     end
   end
+
+  context 'BIC' do
+    it 'should accept valid BICs' do
+      SEPA::DirectDebitTransaction.should accept('DEUTDEDBDUE', 'DUSSDEDDXXX', for: :bic)
+    end
+
+    it 'should not accept an invalid BIC' do
+      SEPA::DirectDebitTransaction.should_not accept('','GENODE61HR', 'DEUTDEDBDUEDEUTDEDBDUE', for: :bic)
+    end
+  end
 end


### PR DESCRIPTION
BICValidator allowed invalid BICs which matched the regular expression
but had additional invalid characters padded to the beginning or ending.

Example:
GENODE61HR

That BIC passed the validation although it's invalid and gets rejected by the bank after uploading the file (Commerzbank&Sparkasse).
