### PR TITLE
show account error details on message validation

### DIFF
--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -13,7 +13,7 @@ module SEPA
 
     validates_presence_of :transactions
     validate do |record|
-      record.errors.add(:account, 'is invalid') unless record.account.valid?
+      record.errors.add(:account, record.account.errors.full_messages) unless record.account.valid?
     end
 
     class_attribute :account_class, :transaction_class, :xml_main_tag, :known_schemas

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -33,7 +33,7 @@ describe SEPA::Message do
 
     it 'should fail with invalid account' do
       subject.should_not be_valid
-      subject.should have(1).error_on(:account)
+      subject.should have(2).error_on(:account)
     end
 
     it 'should fail without transactions' do


### PR DESCRIPTION
so one does not need to make a roundtrip into the account and can see whats wrong when the errors is raised e.g in message.to_xml  
