### PR TITLE
allow space in mandate id

### DIFF
--- a/lib/sepa_king/validator.rb
+++ b/lib/sepa_king/validator.rb
@@ -50,7 +50,7 @@ module SEPA
   end
 
   class MandateIdentifierValidator < ActiveModel::Validator
-    REGEX = /\A([A-Za-z0-9]|[\+|\?|\/|\-|\:|\(|\)|\.|\,|\']){1,35}\z/
+    REGEX = /\A([A-Za-z0-9]|[ \+|\?|\/|\-|\:|\(|\)|\.|\,|\']){1,35}\z/
 
     def validate(record)
       field_name = options[:field_name] || :mandate_id

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -61,10 +61,10 @@ describe SEPA::MandateIdentifierValidator do
   end
 
   it 'should accept valid mandate_identifier' do
-    Validatable.should accept('XYZ-123', "+?/-:().,'", 'X' * 35, for: [:mandate_id, :mid])
+    Validatable.should accept('XY Z-123', "+?/-:().,'", 'X' * 35, for: [:mandate_id, :mid])
   end
 
   it 'should not accept an invalid mandate_identifier' do
-    Validatable.should_not accept(nil, '', 'X' * 36, 'ABC 123', '#/*', 'Ümläüt', for: [:mandate_id, :mid])
+    Validatable.should_not accept(nil, '', 'X' * 36, '#/*', 'Ümläüt', for: [:mandate_id, :mid])
   end
 end


### PR DESCRIPTION
My mandate IDs have spaces. My bank seems to allow that. Is it explicitly forbidden somewhere?
