### PR TITLE
Remove the hard-coded German transliteration rules

### DIFF
--- a/lib/sepa_king/converter.rb
+++ b/lib/sepa_king/converter.rb
@@ -18,17 +18,7 @@ module SEPA
       def convert_text(value)
         return unless value
 
-        text = value.to_s.
-          # Convert german umlauts
-          gsub('Ä', 'AE').
-          gsub('Ü', 'UE').
-          gsub('Ö', 'OE').
-          gsub('ä', 'ae').
-          gsub('ü', 'ue').
-          gsub('ö', 'oe').
-          gsub('ß', 'ss')
-
-        I18n.transliterate(text).
+        I18n.transliterate(value.to_s).
           # Change linebreaks to whitespaces
           gsub(/\n+/,' ').
           # Remove all invalid characters

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -14,7 +14,7 @@ describe SEPA::Converter do
     end
 
     it 'should convert umlaute' do
-      convert_text('üöäÜÖÄß').should == 'ueoeaeUEOEAEss'
+      convert_text('üöäÜÖÄß').should == 'uoaUOAss'
     end
 
     it 'should convert line breaks' do

--- a/spec/direct_debit_spec.rb
+++ b/spec/direct_debit_spec.rb
@@ -192,7 +192,7 @@ describe SEPA::DirectDebit do
         end
 
         it 'should contain <Cdtr>' do
-          subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf/Cdtr/Nm', 'Glaeubiger GmbH')
+          subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf/Cdtr/Nm', 'Glaubiger GmbH')
         end
 
         it 'should contain <CdtrAcct>' do
@@ -233,7 +233,7 @@ describe SEPA::DirectDebit do
         end
 
         it 'should contain <Dbtr>' do
-          subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[1]/Dbtr/Nm', 'Zahlemann  Soehne GbR')
+          subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[1]/Dbtr/Nm', 'Zahlemann  Sohne GbR')
           subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[2]/Dbtr/Nm', 'Meier  Schulze oHG')
         end
 
@@ -244,7 +244,7 @@ describe SEPA::DirectDebit do
 
         it 'should contain <RmtInf>' do
           subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[1]/RmtInf/Ustrd', 'Unsere Rechnung vom 10.08.2013')
-          subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[2]/RmtInf/Ustrd', 'Vielen Dank fuer Ihren Einkauf')
+          subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[2]/RmtInf/Ustrd', 'Vielen Dank fur Ihren Einkauf')
         end
       end
 
@@ -381,7 +381,7 @@ describe SEPA::DirectDebit do
         end
 
         it 'should contain two payment_informations with <Cdtr>' do
-          subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf[1]/Cdtr/Nm', 'Glaeubiger GmbH')
+          subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf[1]/Cdtr/Nm', 'Glaubiger GmbH')
           subject.should have_xml('//Document/CstmrDrctDbtInitn/PmtInf[2]/Cdtr/Nm', 'Creditor Inc.')
         end
       end


### PR DESCRIPTION
I would propose to remove the hard-coded transliteration rules for German, because those rules do not apply to other countries using the same letters (in this case: Estonian).

This commit removes the hardcoded info and enables transliteration rules to be chosen with
`I18n.locale = :en`, like so:

```
# Select the correct locale
I18n.locale = :de

# First: Create the main object
sct = SEPA::CreditTransfer.new(
  # Name of the initiating party and debtor, in German: "Auftraggeber"
  # String, max. 70 char
  name: "Auftraggeber",
  ...
```
