### PR TITLE
Randomize MsgId

### DIFF
--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -70,7 +70,7 @@ module SEPA
 
     # Unique identifer for the whole message
     def message_identification
-      @message_identification ||= "SEPA-KING/#{Time.now.to_i}"
+      @message_identification ||= "SEPA-KING/#{SecureRandom.hex[0..22]}"
     end
 
     # Returns the id of the batch to which the given transaction belongs

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 describe SEPA::CreditTransfer do
+  let(:message_id_regex) { /SEPA-KING\/[0-9a-z_]{23}/ }
   let(:credit_transfer) {
     SEPA::CreditTransfer.new name:       'Schuldner GmbH',
                              bic:        'BANKDEFFXXX',
@@ -120,11 +121,11 @@ describe SEPA::CreditTransfer do
         end
 
         it 'should have message_identification' do
-          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/GrpHdr/MsgId', /SEPA-KING\/[0-9]+/)
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/GrpHdr/MsgId', message_id_regex)
         end
 
         it 'should contain <PmtInfId>' do
-          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/PmtInfId', /SEPA-KING\/[0-9]+\/1/)
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/PmtInfId', /#{message_id_regex}\/1/)
         end
 
         it 'should contain <ReqdExctnDt>' do
@@ -209,8 +210,8 @@ describe SEPA::CreditTransfer do
         end
 
         it 'should contain two payment_informations with different <PmtInfId>' do
-          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf[1]/PmtInfId', /SEPA-KING\/[0-9]+\/1/)
-          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf[2]/PmtInfId', /SEPA-KING\/[0-9]+\/2/)
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf[1]/PmtInfId', /#{message_id_regex}\/1/)
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf[2]/PmtInfId', /#{message_id_regex}\/2/)
         end
       end
 

--- a/spec/direct_debit_spec.rb
+++ b/spec/direct_debit_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 
 describe SEPA::DirectDebit do
+  let(:message_id_regex) { /SEPA-KING\/[0-9a-z_]{23}/ }
+
   let(:direct_debit) {
     SEPA::DirectDebit.new name:                'Gläubiger GmbH',
                           bic:                 'BANKDEFFXXX',
@@ -37,7 +39,7 @@ describe SEPA::DirectDebit do
     it 'returns the id of the batch where the given transactions belongs to (1 batch)' do
       direct_debit.add_transaction(direct_debt_transaction(reference: "EXAMPLE REFERENCE"))
 
-      expect(direct_debit.batch_id("EXAMPLE REFERENCE")).to match(/SEPA-KING\/[0-9]+\/1/)
+      expect(direct_debit.batch_id("EXAMPLE REFERENCE")).to match(/#{message_id_regex}\/1/)
     end
 
     it 'returns the id of the batch where the given transactions belongs to (2 batches)' do
@@ -45,9 +47,9 @@ describe SEPA::DirectDebit do
       direct_debit.add_transaction(direct_debt_transaction(reference: "EXAMPLE REFERENCE 2", requested_date: Date.today.next.next))
       direct_debit.add_transaction(direct_debt_transaction(reference: "EXAMPLE REFERENCE 3"))
 
-      expect(direct_debit.batch_id("EXAMPLE REFERENCE 1")).to match(/SEPA-KING\/[0-9]+\/1/)
-      expect(direct_debit.batch_id("EXAMPLE REFERENCE 2")).to match(/SEPA-KING\/[0-9]+\/2/)
-      expect(direct_debit.batch_id("EXAMPLE REFERENCE 3")).to match(/SEPA-KING\/[0-9]+\/1/)
+      expect(direct_debit.batch_id("EXAMPLE REFERENCE 1")).to match(/#{message_id_regex}\/1/)
+      expect(direct_debit.batch_id("EXAMPLE REFERENCE 2")).to match(/#{message_id_regex}\/2/)
+      expect(direct_debit.batch_id("EXAMPLE REFERENCE 3")).to match(/#{message_id_regex}\/1/)
     end
   end
 
@@ -58,8 +60,8 @@ describe SEPA::DirectDebit do
       direct_debit.add_transaction(direct_debt_transaction(reference: "EXAMPLE REFERENCE 3"))
 
       expect(direct_debit.batches.size).to eq(2)
-      expect(direct_debit.batches[0]).to match(/SEPA-KING\/[0-9]+/)
-      expect(direct_debit.batches[1]).to match(/SEPA-KING\/[0-9]+/)
+      expect(direct_debit.batches[0]).to match(/#{message_id_regex}\/[0-9]+/)
+      expect(direct_debit.batches[1]).to match(/#{message_id_regex}\/[0-9]+/)
     end
   end
 
@@ -164,7 +166,7 @@ describe SEPA::DirectDebit do
         end
 
         it 'should have message_identification' do
-          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/GrpHdr/MsgId', /SEPA-KING\/[0-9]+/)
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/GrpHdr/MsgId', message_id_regex)
         end
 
         it 'should have creditor identifier' do
@@ -172,7 +174,7 @@ describe SEPA::DirectDebit do
         end
 
         it 'should contain <PmtInfId>' do
-          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/PmtInfId', /SEPA-KING\/[0-9]+\/1/)
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/PmtInfId', /#{message_id_regex}\/1/)
         end
 
         it 'should contain <ReqdColltnDt>' do
@@ -271,8 +273,8 @@ describe SEPA::DirectDebit do
         end
 
         it 'should contain two payment_informations with different <PmtInfId>' do
-          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf[1]/PmtInfId', /SEPA-KING\/[0-9]+\/1/)
-          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf[2]/PmtInfId', /SEPA-KING\/[0-9]+\/2/)
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf[1]/PmtInfId', /#{message_id_regex}\/1/)
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf[2]/PmtInfId', /#{message_id_regex}\/2/)
         end
       end
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -43,10 +43,14 @@ describe SEPA::Message do
   end
 
   describe :message_identification do
+    before do
+      allow(SecureRandom).to receive(:hex).and_return("randomidentificationstr-ignored_from_here")
+    end
+
     subject { DummyMessage.new }
 
     it 'should have a reader method' do
-      expect(subject.message_identification).to match(/SEPA-KING\/[0-9]+/)
+      expect(subject.message_identification).to eql('SEPA-KING/randomidentificationstr')
     end
 
     it 'should have a writer method' do


### PR DESCRIPTION
This change creates a random message id in order to avoid rejections because of duplicate message ids. 

Before this change, the message identifier contained a timestamp with seconds. So 2 messages created within the same second had the same message id and thus, some banks rejected the messages.
