### PR TITLE
Handle mandate amendments for direct debit transactions.

### DIFF
--- a/lib/sepa_king/message/direct_debit.rb
+++ b/lib/sepa_king/message/direct_debit.rb
@@ -83,6 +83,28 @@ module SEPA
       end
     end
 
+    def build_amendment_informations(builder, transaction)
+      return unless transaction.original_debtor_account || transaction.same_mandate_new_debtor_agent
+      builder.AmdmntInd(true)
+      builder.AmdmntInfDtls do
+        if transaction.original_debtor_account
+          builder.OrgnlDbtrAcct do
+            builder.Id do
+              builder.IBAN(transaction.original_debtor_account)
+            end
+          end
+        else
+          builder.OrgnlDbtrAgt do
+            builder.FinInstnId do
+              builder.Othr do
+                builder.Id('SMNDA')
+              end
+            end
+          end
+        end
+      end
+    end
+
     def build_transaction(builder, transaction)
       builder.DrctDbtTxInf do
         builder.PmtId do
@@ -93,6 +115,7 @@ module SEPA
           builder.MndtRltdInf do
             builder.MndtId(transaction.mandate_id)
             builder.DtOfSgntr(transaction.mandate_date_of_signature.iso8601)
+            build_amendment_informations(builder, transaction)
           end
         end
         builder.DbtrAgt do

--- a/lib/sepa_king/transaction/direct_debit_transaction.rb
+++ b/lib/sepa_king/transaction/direct_debit_transaction.rb
@@ -4,7 +4,7 @@ module SEPA
     SEQUENCE_TYPES = %w(FRST OOFF RCUR FNAL)
     LOCAL_INSTRUMENTS = %w(CORE COR1 B2B)
 
-    attr_accessor :mandate_id, :mandate_date_of_signature, :local_instrument, :sequence_type, :creditor_account
+    attr_accessor :mandate_id, :mandate_date_of_signature, :local_instrument, :sequence_type, :creditor_account, :original_debtor_account, :same_mandate_new_debtor_agent
 
     validates_with MandateIdentifierValidator, field_name: :mandate_id
     validates_presence_of :mandate_date_of_signature

--- a/spec/direct_debit_spec.rb
+++ b/spec/direct_debit_spec.rb
@@ -389,6 +389,26 @@ describe SEPA::DirectDebit do
           expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf[2]/Cdtr/Nm', 'Creditor Inc.')
         end
       end
+
+      context 'with mandate amendments' do
+        subject do
+          sdd = direct_debit
+
+          sdd.add_transaction(direct_debt_transaction.merge(original_debtor_account: 'NL08RABO0135742099'))
+          sdd.add_transaction(direct_debt_transaction.merge(same_mandate_new_debtor_agent: true))
+          sdd.to_xml
+        end
+
+        it 'should include amendment indicator' do
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[1]/DrctDbtTx/MndtRltdInf/AmdmntInd', 'true')
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[2]/DrctDbtTx/MndtRltdInf/AmdmntInd', 'true')
+        end
+
+        it 'should include amendment information details' do
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[1]/DrctDbtTx/MndtRltdInf/AmdmntInfDtls/OrgnlDbtrAcct/Id/IBAN', 'NL08RABO0135742099')
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[2]/DrctDbtTx/MndtRltdInf/AmdmntInfDtls/OrgnlDbtrAgt/FinInstnId/Othr/Id', 'SMNDA')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

Thanks for the gem, we've been using it for quite some time now.
We've had some issues with some of our direct debit transactions being declined following an IBAN and or BIC change on the mandate. After reading the specs, we made some modifications to be able to add amendment informations.
These modifications have been successfully used for this month direct debit transactions batch at Doctolib.