### PR TITLE
Make 1999-01-01 the default requested_date (as proposed in #18)

### DIFF
--- a/lib/sepa_king/transaction.rb
+++ b/lib/sepa_king/transaction.rb
@@ -4,6 +4,8 @@ module SEPA
     include ActiveModel::Validations
     extend Converter
 
+    DEFAULT_REQUESTED_DATE = Date.new(1999, 1, 1).freeze
+
     attr_accessor :name, :iban, :bic, :amount, :instruction, :reference, :remittance_information, :requested_date, :batch_booking
     convert :name, :instruction, :reference, :remittance_information, to: :text
     convert :amount, to: :decimal
@@ -22,9 +24,19 @@ module SEPA
         send("#{name}=", value)
       end
 
-      self.requested_date ||= Date.today.next
+      self.requested_date ||= DEFAULT_REQUESTED_DATE
       self.reference ||= 'NOTPROVIDED'
       self.batch_booking = true if self.batch_booking.nil?
+    end
+
+    protected
+
+    def validate_requested_date_after(min_requested_date)
+      return unless requested_date.is_a?(Date)
+
+      if requested_date != DEFAULT_REQUESTED_DATE && requested_date < min_requested_date
+        errors.add(:requested_date, "must be greater or equal to #{min_requested_date}, or nil")
+      end
     end
   end
 end

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -5,11 +5,7 @@ module SEPA
 
     validates_inclusion_of :service_level, :in => %w(SEPA URGP)
 
-    validate do |t|
-      if t.requested_date.is_a?(Date)
-        errors.add(:requested_date, 'is in the past') if t.requested_date < Date.today
-      end
-    end
+    validate { |t| t.validate_requested_date_after(Date.today) }
 
     def initialize(attributes = {})
       super

--- a/lib/sepa_king/transaction/direct_debit_transaction.rb
+++ b/lib/sepa_king/transaction/direct_debit_transaction.rb
@@ -11,6 +11,8 @@ module SEPA
     validates_inclusion_of :local_instrument, in: LOCAL_INSTRUMENTS
     validates_inclusion_of :sequence_type, in: SEQUENCE_TYPES
 
+    validate { |t| t.validate_requested_date_after(Date.today.next) }
+
     validate do |t|
       if creditor_account
         errors.add(:creditor_account, 'is not correct') unless creditor_account.valid?
@@ -20,10 +22,6 @@ module SEPA
         errors.add(:mandate_date_of_signature, 'is in the future') if t.mandate_date_of_signature > Date.today
       else
         errors.add(:mandate_date_of_signature, 'is not a Date')
-      end
-
-      if t.requested_date.is_a?(Date)
-        errors.add(:requested_date, 'is not in the future') if t.requested_date <= Date.today
       end
     end
 

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -129,7 +129,7 @@ describe SEPA::CreditTransfer do
         end
 
         it 'should contain <ReqdExctnDt>' do
-          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/ReqdExctnDt', Date.today.next.iso8601)
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/ReqdExctnDt', Date.new(1999, 1, 1).iso8601)
         end
 
         it 'should contain <PmtMtd>' do

--- a/spec/credit_transfer_transaction_spec.rb
+++ b/spec/credit_transfer_transaction_spec.rb
@@ -36,7 +36,7 @@ describe SEPA::CreditTransferTransaction do
 
   context 'Requested date' do
     it 'should allow valid value' do
-      expect(SEPA::CreditTransferTransaction).to accept(nil, Date.today, Date.today.next, Date.today + 2, for: :requested_date)
+      expect(SEPA::CreditTransferTransaction).to accept(nil, Date.new(1999, 1, 1), Date.today, Date.today.next, Date.today + 2, for: :requested_date)
     end
 
     it 'should not allow invalid value' do

--- a/spec/direct_debit_spec.rb
+++ b/spec/direct_debit_spec.rb
@@ -178,7 +178,7 @@ describe SEPA::DirectDebit do
         end
 
         it 'should contain <ReqdColltnDt>' do
-          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/ReqdColltnDt', Date.today.next.iso8601)
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/ReqdColltnDt', Date.new(1999, 1, 1).iso8601)
         end
 
         it 'should contain <PmtMtd>' do

--- a/spec/direct_debit_transaction_spec.rb
+++ b/spec/direct_debit_transaction_spec.rb
@@ -48,7 +48,7 @@ describe SEPA::DirectDebitTransaction do
 
   context 'Requested date' do
     it 'should allow valid value' do
-      expect(SEPA::DirectDebitTransaction).to accept(nil, Date.today.next, Date.today + 2, for: :requested_date)
+      expect(SEPA::DirectDebitTransaction).to accept(nil, Date.new(1999, 1, 1), Date.today.next, Date.today + 2, for: :requested_date)
     end
 
     it 'should not allow invalid value' do

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -8,7 +8,7 @@ describe SEPA::Transaction do
     end
 
     it 'should have default for requested_date' do
-      expect(SEPA::Transaction.new.requested_date).to eq(Date.today.next)
+      expect(SEPA::Transaction.new.requested_date).to eq(Date.new(1999, 1, 1))
     end
 
     it 'should have default for batch_booking' do


### PR DESCRIPTION
A draft of the proposed changes from #18.

The validation of the requested_date is now refactored into a method of the Transaction class that takes the minimum date that is okay for the transaction type (Date.today for Credit Transfer, Date.tomorrow for DirectDebit).

All direct debits and credit transfers have now a requested_date of 1999-01-01 instead of Date.today that comes from a freezed constant.

Specs are changed accordingly.

Please review :-)