### PR TITLE
Show Invalid IBAN with error message

### DIFF
--- a/lib/sepa_king/account.rb
+++ b/lib/sepa_king/account.rb
@@ -8,7 +8,7 @@ module SEPA
     convert :name, to: :text
 
     validates_length_of :name, within: 1..70
-    validates_with BICValidator, IBANValidator
+    validates_with BICValidator, IBANValidator, message: "%{value} is invalid"
 
     def initialize(attributes = {})
       attributes.each do |name, value|

--- a/lib/sepa_king/account/creditor_account.rb
+++ b/lib/sepa_king/account/creditor_account.rb
@@ -3,6 +3,6 @@ module SEPA
   class CreditorAccount < Account
     attr_accessor :creditor_identifier
 
-    validates_with CreditorIdentifierValidator
+    validates_with CreditorIdentifierValidator, message: "%{value} is invalid"
   end
 end

--- a/lib/sepa_king/transaction.rb
+++ b/lib/sepa_king/transaction.rb
@@ -17,7 +17,7 @@ module SEPA
     validates_numericality_of :amount, greater_than: 0
     validates_presence_of :requested_date
     validates_inclusion_of :batch_booking, :in => [true, false]
-    validates_with BICValidator, IBANValidator
+    validates_with BICValidator, IBANValidator, message: "%{value} is invalid"
 
     def initialize(attributes = {})
       attributes.each do |name, value|

--- a/lib/sepa_king/transaction/direct_debit_transaction.rb
+++ b/lib/sepa_king/transaction/direct_debit_transaction.rb
@@ -6,7 +6,7 @@ module SEPA
 
     attr_accessor :mandate_id, :mandate_date_of_signature, :local_instrument, :sequence_type, :creditor_account, :original_debtor_account, :same_mandate_new_debtor_agent
 
-    validates_with MandateIdentifierValidator, field_name: :mandate_id
+    validates_with MandateIdentifierValidator, field_name: :mandate_id, message: "%{value} is invalid"
     validates_presence_of :mandate_date_of_signature
     validates_inclusion_of :local_instrument, in: LOCAL_INSTRUMENTS
     validates_inclusion_of :sequence_type, in: SEQUENCE_TYPES

--- a/lib/sepa_king/validator.rb
+++ b/lib/sepa_king/validator.rb
@@ -9,7 +9,7 @@ module SEPA
       value = record.send(field_name).to_s
 
       unless IBANTools::IBAN.valid?(value) && value.match(REGEX)
-        record.errors.add(field_name, :invalid, message: "is invalid (#{value})")
+        record.errors.add(field_name, :invalid, message: options[:message])
       end
     end
   end
@@ -24,7 +24,7 @@ module SEPA
 
       if value
         unless value.to_s.match(REGEX)
-          record.errors.add(field_name, :invalid)
+          record.errors.add(field_name, :invalid, message: options[:message])
         end
       end
     end
@@ -38,7 +38,7 @@ module SEPA
       value = record.send(field_name)
 
       unless valid?(value)
-        record.errors.add(field_name, :invalid)
+        record.errors.add(field_name, :invalid, message: options[:message])
       end
     end
 
@@ -61,7 +61,7 @@ module SEPA
       value = record.send(field_name)
 
       unless value.to_s.match(REGEX)
-        record.errors.add(field_name, :invalid)
+        record.errors.add(field_name, :invalid, message: options[:message])
       end
     end
   end

--- a/lib/sepa_king/validator.rb
+++ b/lib/sepa_king/validator.rb
@@ -9,7 +9,7 @@ module SEPA
       value = record.send(field_name).to_s
 
       unless IBANTools::IBAN.valid?(value) && value.match(REGEX)
-        record.errors.add(field_name, :invalid, message: "(#{value})")
+        record.errors.add(field_name, :invalid, message: "is invalid (#{value})")
       end
     end
   end

--- a/lib/sepa_king/validator.rb
+++ b/lib/sepa_king/validator.rb
@@ -9,7 +9,7 @@ module SEPA
       value = record.send(field_name).to_s
 
       unless IBANTools::IBAN.valid?(value) && value.match(REGEX)
-        record.errors.add(field_name, :invalid)
+        record.errors.add(field_name, :invalid, message: "(#{value})")
       end
     end
   end


### PR DESCRIPTION
We had two case for creating Sepa Files. 

- Read customer records from DB
- Read records from TXT file

If there are any invalid IBANs present in DB or the file, the gem shows an error message "IBAN is invalid" and its hard to find which one when you have 500+ records in DB or TXT file. So, instead of only showing a generic message that IBAN is invalid, also show the faulty IBAN for removing invalid IBANs.