### PR TITLE
Adds InstrId support for direct debits

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ sct.add_transaction(
   # Number with two decimal digit
   amount:                 102.50,
 
+  # OPTIONAL: Instruction Identification, will not be submitted to the creditor
+  # String, max. 35 char
+  instruction:               '12345',
+
   # OPTIONAL: End-To-End-Identification, will be submitted to the creditor
   # String, max. 35 char
   reference:              'XYZ-1234/123',

--- a/lib/sepa_king/message/direct_debit.rb
+++ b/lib/sepa_king/message/direct_debit.rb
@@ -108,6 +108,9 @@ module SEPA
     def build_transaction(builder, transaction)
       builder.DrctDbtTxInf do
         builder.PmtId do
+          if transaction.instruction.present?
+            builder.InstrId(transaction.instruction)
+          end
           builder.EndToEndId(transaction.reference)
         end
         builder.InstdAmt('%.2f' % transaction.amount, Ccy: 'EUR')

--- a/spec/direct_debit_spec.rb
+++ b/spec/direct_debit_spec.rb
@@ -411,6 +411,24 @@ describe SEPA::DirectDebit do
           expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[2]/DrctDbtTx/MndtRltdInf/AmdmntInfDtls/OrgnlDbtrAgt/FinInstnId/Othr/Id', 'SMNDA')
         end
       end
+
+      context 'with instruction given' do
+        subject do
+          sct = direct_debit
+
+          sct.add_transaction(direct_debt_transaction.merge(instruction: '1234/ABC'))
+
+          sct.to_xml
+        end
+
+        it 'should create valid XML file' do
+          expect(subject).to validate_against('pain.008.003.02.xsd')
+        end
+
+        it 'should contain <InstrId>' do
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[1]/PmtId/InstrId', '1234/ABC')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Also added 'instruction' to credit transfer example in README

Solves the issue opened in https://github.com/salesking/sepa_king/issues/56