### PR TITLE
Getter/setter for creation_date_time and Issue 58

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ pkg/*
 Gemfile.lock
 # tmp disable
 docs/
+.idea
+.ruby-version
+.ruby-gemset

--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -14,6 +14,7 @@ module SEPA
     attr_reader :account, :grouped_transactions
 
     validates_presence_of :transactions
+    validate :length_of_payment_information_identifications
     validate do |record|
       record.errors.add(:account, record.account.errors.full_messages) unless record.account.valid?
     end
@@ -146,6 +147,13 @@ module SEPA
     # Returns a key to determine the group to which the transaction belongs
     def transaction_group(transaction)
       transaction
+    end
+
+    def length_of_payment_information_identifications
+      grouped_transactions.keys.each do |group|
+        value = payment_information_identification(group)
+        errors.add :payment_information_identification, 'is longer than 35 characters!' unless value.length <= 35
+      end
     end
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -85,4 +85,44 @@ describe SEPA::Message do
       end
     end
   end
+
+  describe :creation_date_time do
+    subject { DummyMessage.new }
+
+    describe 'getter' do
+      it 'should return Time.now.iso8601' do
+        expect(subject.creation_date_time).to eq(Time.now.iso8601)
+      end
+    end
+
+    describe 'setter' do
+      it 'should accept date time strings' do
+        ['2017-01-05T12:28:52', '2017-01-05T12:28:52Z', '2017-01-05 12:28:52', '2017-01-05T12:28:52+01:00'].each do |valid_dt|
+          subject.creation_date_time = valid_dt
+          expect(subject.creation_date_time).to eq(valid_dt)
+        end
+      end
+
+      it 'should deny invalid string' do
+        [ 'an arbitrary string',
+          ''
+        ].each do |arg|
+          expect {
+            subject.creation_date_time = arg
+          }.to raise_error(ArgumentError)
+        end
+      end
+
+      it 'should deny argument other than String' do
+        [ 123,
+          nil,
+          :foo
+        ].each do |arg|
+          expect {
+            subject.creation_date_time = arg
+          }.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -42,6 +42,26 @@ describe SEPA::Message do
     end
   end
 
+  describe 'validation of payment_information_identification' do
+    subject do
+      message = DummyMessage.new
+      message.add_transaction amount: 1.1
+      message.add_transaction amount: 2.2
+      message
+    end
+
+    it 'should not fail if length is ok' do
+      subject.message_identification = 'shortID'
+      expect(subject.errors_on(:payment_information_identification).size).to eq(0)
+    end
+
+    it 'should fail if length is too long' do
+      subject.message_identification = 'A' * 35
+      expect(subject).not_to be_valid
+      expect(subject.errors_on(:payment_information_identification).size).to eq(2)
+    end
+  end
+
   describe :message_identification do
     subject { DummyMessage.new }
 


### PR DESCRIPTION
The Rabobank in the Netherlands does not accept the iso8601 format which includes the Timezone. A getter/setter was added for creation_date_time so that a custom value can be set.

Also a solution for Issue 58 was added. 