### PR TITLE
Allow empty BIC for pain.001.001.03 credit transfers

### DIFF
--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -15,7 +15,7 @@ module SEPA
     def schema_compatible?(schema_name)
       case schema_name
       when PAIN_001_001_03
-        self.bic.present? && self.service_level == 'SEPA'
+        self.service_level == 'SEPA'
       when PAIN_001_002_03
         self.bic.present? && self.service_level == 'SEPA' && self.currency == 'EUR'
       when PAIN_001_003_03

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -62,6 +62,12 @@ describe SEPA::CreditTransfer do
           expect(subject.to_xml).to validate_against('pain.001.003.03.xsd')
         end
 
+        it 'should fail for pain.001.001.03' do
+          expect {
+            subject.to_xml(SEPA::PAIN_001_001_03)
+          }.to raise_error(RuntimeError)
+        end
+
         it 'should fail for pain.001.002.03' do
           expect {
             subject.to_xml(SEPA::PAIN_001_002_03)
@@ -325,6 +331,32 @@ describe SEPA::CreditTransfer do
           expect {
             subject.to_xml(SEPA::PAIN_001_003_03)
           }.to raise_error(RuntimeError)
+        end
+      end
+
+      context 'with a transaction without a bic' do
+        subject do
+          sct = credit_transfer
+
+          sct.add_transaction name:                   'Telekomiker AG',
+                              iban:                   'DE37112589611964645802',
+                              amount:                 102.50
+
+          sct
+        end
+
+        it 'should validate against pain.001.001.03' do
+          expect(subject.to_xml('pain.001.001.03')).to validate_against('pain.001.001.03.xsd')
+        end
+
+        it 'should fail for pain.001.002.03' do
+          expect {
+            subject.to_xml(SEPA::PAIN_001_002_03)
+          }.to raise_error(RuntimeError)
+        end
+
+        it 'should validate against pain.001.003.03' do
+          expect(subject.to_xml(SEPA::PAIN_001_003_03)).to validate_against('pain.001.003.03.xsd')
         end
       end
     end

--- a/spec/credit_transfer_transaction_spec.rb
+++ b/spec/credit_transfer_transaction_spec.rb
@@ -41,6 +41,7 @@ describe SEPA::CreditTransferTransaction do
     context 'for pain.001.001.03' do
       it 'should succeed for valid attributes' do
         expect(SEPA::CreditTransferTransaction.new(:bic => 'SPUEDE2UXXX', :currency => 'CHF')).to be_schema_compatible('pain.001.001.03')
+        expect(SEPA::CreditTransferTransaction.new(:bic => nil)).to be_schema_compatible('pain.001.003.03')
       end
     end
   end


### PR DESCRIPTION
Hello,

The pain.001.001.03 format does not require the presence of a `CdtrAgt` block, so there is no need to make the BIC mandatory for transactions using this format.

I added a test that should cover the 3 credit transfer formats.