### PR TITLE
mandate amendments for direct debit transactions with creditor id or name change

### DIFF
--- a/lib/sepa_king/transaction/direct_debit_transaction.rb
+++ b/lib/sepa_king/transaction/direct_debit_transaction.rb
@@ -4,7 +4,7 @@ module SEPA
     SEQUENCE_TYPES = %w(FRST OOFF RCUR FNAL)
     LOCAL_INSTRUMENTS = %w(CORE COR1 B2B)
 
-    attr_accessor :mandate_id, :mandate_date_of_signature, :local_instrument, :sequence_type, :creditor_account, :original_debtor_account, :same_mandate_new_debtor_agent
+    attr_accessor :mandate_id, :mandate_date_of_signature, :local_instrument, :sequence_type, :creditor_account, :original_debtor_account, :same_mandate_new_debtor_agent, :original_creditor_account
 
     validates_with MandateIdentifierValidator, field_name: :mandate_id, message: "%{value} is invalid"
     validates_presence_of :mandate_date_of_signature
@@ -29,6 +29,10 @@ module SEPA
       super
       self.local_instrument ||= 'CORE'
       self.sequence_type ||= 'OOFF'
+    end
+
+    def amendment_informations?
+      original_debtor_account || same_mandate_new_debtor_agent || original_creditor_account
     end
 
     def schema_compatible?(schema_name)

--- a/spec/direct_debit_spec.rb
+++ b/spec/direct_debit_spec.rb
@@ -398,17 +398,21 @@ describe SEPA::DirectDebit do
 
           sdd.add_transaction(direct_debt_transaction.merge(original_debtor_account: 'NL08RABO0135742099'))
           sdd.add_transaction(direct_debt_transaction.merge(same_mandate_new_debtor_agent: true))
+          sdd.add_transaction(direct_debt_transaction.merge(original_creditor_account: SEPA::CreditorAccount.new(creditor_identifier: 'NL53ZZZ091734220000', name: 'Creditor Inc.')))
           sdd.to_xml
         end
 
         it 'should include amendment indicator' do
           expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[1]/DrctDbtTx/MndtRltdInf/AmdmntInd', 'true')
           expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[2]/DrctDbtTx/MndtRltdInf/AmdmntInd', 'true')
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[3]/DrctDbtTx/MndtRltdInf/AmdmntInd', 'true')
         end
 
         it 'should include amendment information details' do
           expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[1]/DrctDbtTx/MndtRltdInf/AmdmntInfDtls/OrgnlDbtrAcct/Id/IBAN', 'NL08RABO0135742099')
           expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[2]/DrctDbtTx/MndtRltdInf/AmdmntInfDtls/OrgnlDbtrAgt/FinInstnId/Othr/Id', 'SMNDA')
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[3]/DrctDbtTx/MndtRltdInf/AmdmntInfDtls/OrgnlCdtrSchmeId/Nm', 'Creditor Inc.')
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/PmtInf/DrctDbtTxInf[3]/DrctDbtTx/MndtRltdInf/AmdmntInfDtls/OrgnlCdtrSchmeId/Id/PrvtId/Othr/Id', 'NL53ZZZ091734220000')
         end
       end
 


### PR DESCRIPTION
PR #48 added support for mandate amendments when debtor account changes
This PR adds support for ammendments related to creditor identifer or name change