### PR TITLE
External Organization Identifier Code

### DIFF
--- a/lib/sepa_king/account.rb
+++ b/lib/sepa_king/account.rb
@@ -4,10 +4,14 @@ module SEPA
     include ActiveModel::Validations
     extend Converter
 
-    attr_accessor :name, :iban, :bic
+    attr_accessor :name, :iban, :bic, :external_organisation_id_code
     convert :name, to: :text
 
     validates_length_of :name, within: 1..70
+    validates :external_organisation_id_code,
+              format: { with: /[a-zA-Z]/ },
+              length: { within: 1..4 },
+              if: -> { external_organisation_id_code.present? }
     validates_with BICValidator, IBANValidator, message: "%{value} is invalid"
 
     def initialize(attributes = {})

--- a/lib/sepa_king/account/debtor_account.rb
+++ b/lib/sepa_king/account/debtor_account.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
 module SEPA
   class DebtorAccount < Account
+    attr_accessor :creditor_identifier
+
+    validates_with CreditorIdentifierValidator,
+                   message: "%{value} is invalid",
+                   if: ->(account) { account.creditor_identifier.present? }
   end
 end

--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -120,7 +120,7 @@ module SEPA
                 end if account.external_organisation_id_code.present?
               end
             end
-          end if account.creditor_identifier.present?
+          end if account.respond_to? :creditor_identifier && account.creditor_identifier.present?
         end
       end
     end

--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -120,7 +120,7 @@ module SEPA
                 end if account.external_organisation_id_code.present?
               end
             end
-          end if account.respond_to? :creditor_identifier && account.creditor_identifier.present?
+          end if account.respond_to?(:creditor_identifier) && account.creditor_identifier.present?
         end
       end
     end

--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -115,9 +115,12 @@ module SEPA
             builder.OrgId do
               builder.Othr do
                 builder.Id(account.creditor_identifier)
+                builder.SchmeNm do
+                  builder.Cd(account.external_organisation_id_code)
+                end if account.external_organisation_id_code.present?
               end
             end
-          end if account.respond_to? :creditor_identifier
+          end if account.creditor_identifier.present?
         end
       end
     end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -39,4 +39,14 @@ describe SEPA::Account do
       expect(SEPA::Account).not_to accept('', 'invalid', for: :bic)
     end
   end
+
+  describe :external_organisation_id_code do
+    it 'should accept valid value' do
+      expect(SEPA::Account).to accept(nil, '', 'BANK', 'CUST', for: :external_organisation_id_code)
+    end
+
+    it 'should not accept invalid value' do
+      expect(SEPA::Account).not_to accept('invalid', 0000, for: :external_organisation_id_code)
+    end
+  end
 end

--- a/spec/debtor_account_spec.rb
+++ b/spec/debtor_account_spec.rb
@@ -9,4 +9,23 @@ describe SEPA::DebtorAccount do
                               iban:       'DE87200500001234567890'
     ).to be_valid
   end
+
+  it 'should initialize a new account with creditor_identifier' do
+    expect(
+      SEPA::DebtorAccount.new name:                'Gläubiger GmbH',
+                              bic:                 'BANKDEFFXXX',
+                              iban:                'DE87200500001234567890',
+                              creditor_identifier: 'DE98ZZZ09999999999'
+    ).to be_valid
+  end
+
+  describe :creditor_identifier do
+    it 'should accept valid value' do
+      expect(SEPA::DebtorAccount).to accept(nil, '', 'DE98ZZZ09999999999', 'AT12ZZZ00000000001', 'IT97ZZZA1B2C3D4E5F6G7H8', 'NL97ZZZ123456780001', 'FR12ZZZ123456', for: :creditor_identifier)
+    end
+
+    it 'should not accept invalid value' do
+      expect(SEPA::DebtorAccount).not_to accept('invalid', 'DE98ZZZ099999999990', 'DEAAAAAAAAAAAAAAAA', for: :creditor_identifier)
+    end
+  end
 end

--- a/spec/direct_debit_spec.rb
+++ b/spec/direct_debit_spec.rb
@@ -5,10 +5,11 @@ describe SEPA::DirectDebit do
   let(:message_id_regex) { /SEPA-KING\/[0-9a-z_]{22}/ }
 
   let(:direct_debit) {
-    SEPA::DirectDebit.new name:                'Gläubiger GmbH',
-                          bic:                 'BANKDEFFXXX',
-                          iban:                'DE87200500001234567890',
-                          creditor_identifier: 'DE98ZZZ09999999999'
+    SEPA::DirectDebit.new name:                          'Gläubiger GmbH',
+                          bic:                           'BANKDEFFXXX',
+                          iban:                          'DE87200500001234567890',
+                          creditor_identifier:           'DE98ZZZ09999999999',
+                          external_organisation_id_code: 'BANK'
   }
 
   describe :new do
@@ -235,6 +236,10 @@ describe SEPA::DirectDebit do
 
         it 'should have creditor identifier' do
           expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/GrpHdr/InitgPty/Id/OrgId/Othr/Id', direct_debit.account.creditor_identifier)
+        end
+
+        it 'should have external organisation indentification code' do
+          expect(subject).to have_xml('//Document/CstmrDrctDbtInitn/GrpHdr/InitgPty/Id/OrgId/Othr/SchmeNm/Cd', direct_debit.account.external_organisation_id_code)
         end
 
         it 'should contain <PmtInfId>' do


### PR DESCRIPTION
Finnish banks (including Nordea bank) require the 001.001.03 XML to contain a `Creditor Identifier` and an `External Organization Identifier Code` for their SEPA transfers.

Adding a `Creditor Identifier` to `DebtorAccount` and `External Organization Identifier Code` for `Account` (as it should be available for both creditor as debtor).