### PR TITLE
Add Category Purpose to Credit Transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ sct.add_transaction(
   #   'URGP' ("Taggleiche Eilüberweisung")
   service_level: 'URGP'
 
+  # OPTIONAL: Unstructured information to indicate the purpose of the payment
+  # String, max. 4 char
+  category_purpose:         'SALA',
+
   # OPTIONAL: Specify the country & address of the creditor (REQUIRED for SEPA debits outside of EU. The individually required fields depend on the target country)
   creditor_address: SEPA::CreditorAddress.new(
     country_code:        'CH',

--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -12,7 +12,8 @@ module SEPA
     def transaction_group(transaction)
       { requested_date: transaction.requested_date,
         batch_booking:  transaction.batch_booking,
-        service_level:  transaction.service_level
+        service_level:  transaction.service_level,
+        category_purpose: transaction.category_purpose
       }
     end
 
@@ -30,6 +31,11 @@ module SEPA
             if group[:service_level]
               builder.SvcLvl do
                 builder.Cd(group[:service_level])
+              end
+            end
+            if group[:category_purpose]
+              builder.CtgyPurp do
+                builder.Cd(group[:category_purpose])
               end
             end
           end

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -2,9 +2,11 @@
 module SEPA
   class CreditTransferTransaction < Transaction
     attr_accessor :service_level,
-                  :creditor_address
+                  :creditor_address,
+                  :category_purpose
 
     validates_inclusion_of :service_level, :in => %w(SEPA URGP), :allow_nil => true
+    validates_length_of :category_purpose, within: 1..4, allow_nil: true
 
     validate { |t| t.validate_requested_date_after(Date.today) }
 

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -301,6 +301,7 @@ describe SEPA::CreditTransfer do
           sct.add_transaction(credit_transfer_transaction.merge requested_date: Date.today + 1, batch_booking: true,  amount: 2)
           sct.add_transaction(credit_transfer_transaction.merge requested_date: Date.today + 2, batch_booking: false, amount: 4)
           sct.add_transaction(credit_transfer_transaction.merge requested_date: Date.today + 2, batch_booking: true,  amount: 8)
+          sct.add_transaction(credit_transfer_transaction.merge requested_date: Date.today + 2, batch_booking: true, category_purpose: 'SALA',  amount: 6)
 
           sct.to_xml
         end
@@ -317,6 +318,9 @@ describe SEPA::CreditTransfer do
 
           expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf[4]/ReqdExctnDt', (Date.today + 2).iso8601)
           expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf[4]/BtchBookg', 'true')
+
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf[5]/ReqdExctnDt', (Date.today + 2).iso8601)
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf[5]/PmtTpInf/CtgyPurp/Cd', 'SALA')
         end
 
         it 'should have multiple control sums' do

--- a/spec/credit_transfer_transaction_spec.rb
+++ b/spec/credit_transfer_transaction_spec.rb
@@ -55,4 +55,14 @@ describe SEPA::CreditTransferTransaction do
       expect(SEPA::CreditTransferTransaction).not_to accept(Date.new(1995,12,21), Date.today - 1, for: :requested_date)
     end
   end
+
+  context 'Category Purpose' do
+    it 'should allow valid value' do
+      expect(SEPA::CreditTransferTransaction).to accept(nil, 'SALA', 'X' * 4, for: :category_purpose)
+    end
+
+    it 'should not allow invalid value' do
+      expect(SEPA::CreditTransferTransaction).not_to accept('', 'X' * 5, for: :category_purpose)
+    end
+  end
 end


### PR DESCRIPTION
When you add transactions in a SEPA file, you can specify the category purpose for them. Some banks are a bit strict about this field and if is not specified, those files are going to be rejected.

This PR adds support for providing information for category purpose.

Following specification as defined in:

https://www.europeanpaymentscouncil.eu/sites/default/files/kb/file/2017-11/EPC115-06%20SCT%20Interbank%20IG%202017%20V1.1.pdf

More information:
http://www.sepaforcorporates.com/sepa-payments/sala-sepa-salary-payments/

Some paragraphs from those references:

> In salary payments it is required to declare a code here in order to indicate the purpose of the payment is salary.

> When it comes to payments there is nothing more important than payroll. Every company needs to ensure that their payroll process is happening efficiently, securely and on time. Getting your payroll wrong could result in unauthorised staff getting access to confidential salary information and / or payroll payments not getting out in time, potentially resulting in staff refusing to work. With SEPA salary payments it is important to be aware of the ‘SALA’ Category Purpose value in the SEPA XML payment format – this post will outline the key points.