### PR TITLE
Set explicit utf-8 encoding

### DIFF
--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -41,7 +41,7 @@ module SEPA
       raise SEPA::Error.new(errors.full_messages.join("\n")) unless valid?
       raise SEPA::Error.new("Incompatible with schema #{schema_name}!") unless schema_compatible?(schema_name)
 
-      builder = Nokogiri::XML::Builder.new do |builder|
+      builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |builder|
         builder.Document(xml_schema(schema_name)) do
           builder.__send__(xml_main_tag) do
             build_group_header(builder)


### PR DESCRIPTION
Set the encoding on the XML builder explictly to utf-8.

While it may be useful to be able to pass an encoding for the XML,
UTF-8 will be correct in most cases, and a fixed utf-8 encoding
is preferable to setting no encoding at all.

This should fix #85 and #87 