### PR TITLE
CI: add Rails 7 to the matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ '2.6', '2.7', '3.0' ]
-        rails: [ '4.2', '5.0', '5.1', '5.2', '6.0', '6.1' ]
+        rails: [ '4.2', '5.0', '5.1', '5.2', '6.0', '6.1', '7.0' ]
         exclude:
           - ruby: '2.6'
             rails: '4.0'
           - ruby: '2.6'
             rails: '4.1'
+          - ruby: '2.6'
+            rails: '7.0'
           - ruby: '2.7'
             rails: '4.0'
           - ruby: '2.7'

--- a/gemfiles/Gemfile-activemodel-7.0.x
+++ b/gemfiles/Gemfile-activemodel-7.0.x
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activemodel', '~> 7.0.1'


### PR DESCRIPTION
Rails 7.0 requires Ruby 2.7, so Ruby 2.6 is exluded from the matrix.

**Update:** Sorry, this also needs a Gemfile. **Update 2**: There was go!