### PR TITLE
Drop unused directive from gemspec

### DIFF
--- a/sepa_king.gemspec
+++ b/sepa_king.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
 
   s.files         = `git ls-files`.split($/)
-  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.6'


### PR DESCRIPTION
RubyGems.org are not using test_files for anything.