### PR TITLE
refactor: Prefer __dir__

### DIFF
--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -161,7 +161,7 @@ module SEPA
     end
 
     def validate_final_document!(document, schema_name)
-      xsd = Nokogiri::XML::Schema(File.read(File.expand_path("../../../lib/schema/#{schema_name}.xsd", __FILE__)))
+      xsd = Nokogiri::XML::Schema(File.read(File.expand_path("../../lib/schema/#{schema_name}.xsd", __dir__)))
       errors = xsd.validate(document).map { |error| error.message }
       raise SEPA::Error.new("Incompatible with schema #{schema_name}: #{errors.join(', ')}") if errors.any?
     end

--- a/sepa_king.gemspec
+++ b/sepa_king.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'sepa_king/version'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ require 'sepa_king'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
+Dir[File.expand_path(File.join(__dir__, 'support', '**', '*.rb'))].each {|f| require f}
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
This PR changes usage of `__FILE__` to use `__dir__` where possible.

Ruby 2.7 is the earliest supported Ruby, so we should be good to use this everywhere.