### PR TITLE
test: Fix typo in test context name

### DIFF
--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -26,7 +26,7 @@ describe SEPA::Transaction do
     end
   end
 
-  context 'Adress' do
+  context 'Address' do
     context 'with address_line' do
       it 'should accept valid value' do
         expect(SEPA::Transaction).to accept(SEPA::DebtorAddress.new(


### PR DESCRIPTION
This PR fixes a minor typo in an RSpec context name.