### PR TITLE
Add support for specifying Debtor account per transaction

### DIFF
--- a/lib/sepa_king/account/creditor_account.rb
+++ b/lib/sepa_king/account/creditor_account.rb
@@ -3,6 +3,10 @@ module SEPA
   class CreditorAccount < Account
     attr_accessor :creditor_identifier
 
+    def identifier
+      creditor_identifier
+    end
+
     validates_with CreditorIdentifierValidator, message: "%{value} is invalid"
   end
 end

--- a/lib/sepa_king/account/debtor_account.rb
+++ b/lib/sepa_king/account/debtor_account.rb
@@ -1,5 +1,12 @@
 # encoding: utf-8
 module SEPA
   class DebtorAccount < Account
+    attr_accessor :debtor_identifier
+
+    def identifier
+      debtor_identifier
+    end
+
+    validates_with DebtorIdentifierValidator, message: "%{value} is invalid"
   end
 end

--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -142,10 +142,13 @@ module SEPA
           builder.Id do
             builder.OrgId do
               builder.Othr do
-                builder.Id(account.creditor_identifier)
+                builder.Id(account.identifier)
+                builder.SchmeNm do
+                  builder.Cd('CUST')
+                end
               end
             end
-          end if account.respond_to? :creditor_identifier
+          end if account.identifier
         end
       end
     end

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -3,12 +3,19 @@ module SEPA
   class CreditTransferTransaction < Transaction
     attr_accessor :service_level,
                   :creditor_address,
-                  :category_purpose
+                  :category_purpose,
+                  :debtor_account
 
     validates_inclusion_of :service_level, :in => %w(SEPA URGP), :allow_nil => true
     validates_length_of :category_purpose, within: 1..4, allow_nil: true
 
-    validate { |t| t.validate_requested_date_after(Date.today) }
+    validate do |t|
+      t.validate_requested_date_after(Date.today)
+
+      if debtor_account
+        errors.add(:debtor_account, 'is not correct') unless debtor_account.valid?
+      end
+    end
 
     def initialize(attributes = {})
       super

--- a/lib/sepa_king/validator.rb
+++ b/lib/sepa_king/validator.rb
@@ -58,6 +58,21 @@ module SEPA
     end
   end
 
+  class DebtorIdentifierValidator < ActiveModel::Validator
+    def validate(record)
+      field_name = options[:field_name] || :debtor_identifier
+      value = record.send(field_name)
+
+      unless valid?(value)
+        record.errors.add(field_name, :invalid, message: options[:message])
+      end
+    end
+
+    def valid?(debtor_identifier)
+      debtor_identifier.to_s.length <= 35 # Field is Max35Text
+    end
+  end
+
   class MandateIdentifierValidator < ActiveModel::Validator
     REGEX = %r{\A[A-Za-z0-9 +?/:().,'-]{1,35}\z}
 

--- a/spec/debtor_account_spec.rb
+++ b/spec/debtor_account_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe SEPA::DebtorAccount do
                               iban:       'DE87200500001234567890'
     ).to be_valid
   end
+
+  describe :debtor_identifier do
+    it 'should accept valid value' do
+      expect(SEPA::DebtorAccount).to accept('a'*35, for: :debtor_identifier)
+    end
+
+    it 'should not accept invalid value' do
+      expect(SEPA::DebtorAccount).not_to accept('a'*36, for: :debtor_identifier)
+    end
+  end
 end


### PR DESCRIPTION
_This PR is a reformulation of #101 but with fewer changes in this PR._

This allows you to specify a Debtor account per-transaction.

## Details

`CreditorAccount` and `DebtorAccount` both get a method `#identifier`, which allows the message builder to call that method, not having to check for the presence of it.

Transaction groups also now support the customizing of that identifier.

To support that customization there, the `SchemeNm` `CUST` was added.


