### PR TITLE
Allow empty debtor BIC for pain.001.001.03 credit transfers

### DIFF
--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -46,7 +46,7 @@ module SEPA
         builder.Document(xml_schema(schema_name)) do
           builder.__send__(xml_main_tag) do
             build_group_header(builder)
-            build_payment_informations(builder)
+            build_payment_informations(builder, schema_name)
           end
         end
       end
@@ -63,9 +63,9 @@ module SEPA
       raise ArgumentError.new("Schema #{schema_name} is unknown!") unless self.known_schemas.include?(schema_name)
 
       case schema_name
-        when PAIN_001_002_03, PAIN_008_002_02, PAIN_001_001_03, PAIN_001_001_03_CH_02
+        when PAIN_001_002_03, PAIN_008_002_02
           account.bic.present? && transactions.all? { |t| t.schema_compatible?(schema_name) }
-        when PAIN_001_003_03, PAIN_008_003_02, PAIN_008_001_02
+        when PAIN_001_001_03, PAIN_001_001_03_CH_02, PAIN_001_003_03, PAIN_008_003_02, PAIN_008_001_02
           transactions.all? { |t| t.schema_compatible?(schema_name) }
       end
     end

--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -17,7 +17,7 @@ module SEPA
       }
     end
 
-    def build_payment_informations(builder)
+    def build_payment_informations(builder, schema_name)
       # Build a PmtInf block for every group of transactions
       grouped_transactions.each do |group, transactions|
         # All transactions with the same requested_date are placed into the same PmtInf block
@@ -52,7 +52,7 @@ module SEPA
             builder.FinInstnId do
               if account.bic
                 builder.BIC(account.bic)
-              else
+              elsif schema_name != PAIN_001_001_03_CH_02
                 builder.Othr do
                   builder.Id('NOTPROVIDED')
                 end

--- a/lib/sepa_king/message/direct_debit.rb
+++ b/lib/sepa_king/message/direct_debit.rb
@@ -24,7 +24,7 @@ module SEPA
       }
     end
 
-    def build_payment_informations(builder)
+    def build_payment_informations(builder, schema_name)
       # Build a PmtInf block for every group of transactions
       grouped_transactions.each do |group, transactions|
         builder.PmtInf do

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -105,20 +105,29 @@ RSpec.describe SEPA::CreditTransfer do
                               bic:                    'PBNKDEFF370',
                               iban:                   'DE37112589611964645802',
                               amount:                 102.50,
+                              currency:               currency,
                               reference:              'XYZ-1234/123',
                               remittance_information: 'Rechnung vom 22.08.2013'
 
           sct
         end
 
-        it 'should create valid XML file' do
+        let(:currency) { nil }
+
+        it 'should validate against pain.001.003.03' do
           expect(subject.to_xml(SEPA::PAIN_001_003_03)).to validate_against('pain.001.003.03.xsd')
         end
 
-        it 'should fail for pain.001.001.03' do
-          expect {
-            subject.to_xml(SEPA::PAIN_001_001_03)
-          }.to raise_error(SEPA::Error, /Incompatible with schema/)
+        it 'should validate against pain.001.001.03' do
+          expect(subject.to_xml(SEPA::PAIN_001_001_03)).to validate_against('pain.001.001.03.xsd')
+        end
+
+        context 'with CHF as currency' do
+          let(:currency) { 'CHF' }
+
+          it 'should validate against pain.001.001.03.ch.02' do
+            expect(subject.to_xml(SEPA::PAIN_001_001_03_CH_02)).to validate_against('pain.001.001.03.ch.02.xsd')
+          end
         end
 
         it 'should fail for pain.001.002.03' do


### PR DESCRIPTION
With `pain.001.001.03` a BIC is required for neither the debtor nor creditor.

> [DbtrAgt.BIC] Die Belegung des Elements ist nicht erforderlich.

Source: [pain.001.001.03 spec](https://www.bundesbank.de/resource/blob/848450/c45442007a753501af5086dd8b46df89/mL/technische-spezifikationen-sepa-ueberweisungen-2020-11-data.pdf), page 25

> [DbtrAgt] Debtor Agent will be derived from Debtor Account with IBAN present. Thus is not mandatory.

Source: [pain.001.001.03.ch.02 spec](https://www.credit-suisse.com/media/assets/microsite/docs/zv-migration/pain-001-001-03-six.pdf), page 14

An empty BIC was already accepted for the creditor. This PR removes the requirement from the debtor as well.