### PR TITLE
Add local instrument INST for service level SEPA format pain.001.001.03

### DIFF
--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -13,7 +13,8 @@ module SEPA
       { requested_date: transaction.requested_date,
         batch_booking:  transaction.batch_booking,
         service_level:  transaction.service_level,
-        category_purpose: transaction.category_purpose
+        category_purpose: transaction.category_purpose,
+        local_instrument: transaction.local_instrument
       }
     end
 
@@ -31,6 +32,11 @@ module SEPA
             if group[:service_level]
               builder.SvcLvl do
                 builder.Cd(group[:service_level])
+              end
+            end
+            if group[:local_instrument]
+              builder.LclInstrm do
+                builder.Cd(group[:local_instrument])
               end
             end
             if group[:category_purpose]

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -1,12 +1,18 @@
 # encoding: utf-8
 module SEPA
   class CreditTransferTransaction < Transaction
+    LOCAL_INSTRUMENTS = %w(INST)
+
     attr_accessor :service_level,
                   :creditor_address,
-                  :category_purpose
+                  :category_purpose,
+                  :local_instrument
 
     validates_inclusion_of :service_level, :in => %w(SEPA URGP), :allow_nil => true
     validates_length_of :category_purpose, within: 1..4, allow_nil: true
+    validates_inclusion_of :local_instrument, in: LOCAL_INSTRUMENTS, :allow_nil => true
+
+    validate :inst_valid_for_sepa_service_level
 
     validate { |t| t.validate_requested_date_after(Date.today) }
 
@@ -20,11 +26,19 @@ module SEPA
       when PAIN_001_001_03
         !self.service_level || (self.service_level == 'SEPA' && self.currency == 'EUR')
       when PAIN_001_002_03
-        self.bic.present? && self.service_level == 'SEPA' && self.currency == 'EUR'
+        self.bic.present? && self.service_level == 'SEPA' && self.currency == 'EUR' && self.local_instrument.nil?
       when PAIN_001_003_03
-        self.currency == 'EUR'
+        self.currency == 'EUR' && self.local_instrument.nil?
       when PAIN_001_001_03_CH_02
-        self.currency == 'CHF'
+        self.currency == 'CHF' && self.local_instrument.nil?
+      end
+    end
+
+    private
+
+    def inst_valid_for_sepa_service_level
+      if self.local_instrument == 'INST' && self.service_level != 'SEPA'
+        errors.add(:local_instrument, 'INST can only be used with SEPA service level')
       end
     end
   end

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -525,5 +525,44 @@ RSpec.describe SEPA::CreditTransfer do
         end
       end
     end
+
+    context 'when SEPA INST' do
+      context 'with local instrument INST' do
+        subject do
+          sct = credit_transfer
+
+          sct.add_transaction name:                   'Telekomiker AG',
+                              iban:                   'FR7630003012340001234567854',
+                              bic:                    'SOGEFRPP',
+                              amount:                 345.87,
+                              currency:               'EUR',
+                              local_instrument:       'INST'
+
+          sct
+        end
+
+        it 'should validate against pain.001.001.03' do
+          expect(subject.to_xml(SEPA::PAIN_001_001_03)).to validate_against('pain.001.001.03.xsd')
+        end
+
+        it 'should validate against pain.001.002.03' do
+          expect {
+            subject.to_xml(SEPA::PAIN_001_002_03)
+          }.to raise_error(SEPA::Error, /Incompatible with schema/)
+        end
+
+        it 'should validate against pain.001.003.03' do
+          expect {
+            subject.to_xml(SEPA::PAIN_001_003_03)
+          }.to raise_error(SEPA::Error, /Incompatible with schema/)
+        end
+
+        it 'should fail for pain.001.001.03.CH.02' do
+          expect {
+            subject.to_xml(SEPA::PAIN_001_001_03_CH_02)
+          }.to raise_error(SEPA::Error, /Incompatible with schema/)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
- Add local instrument `INST` for Credit Transfers for pain.001.001.03
- Add validations on CreditTransferTransaction
- Allow only pan.001.001.03 and service level `SEPA` to be compatible with local instrument `INST`

Test passed:

Coverage report generated for RSpec to /Users/danielcomas/dev/sepa_king/coverage.
Line Coverage: 100.0% (491 / 491)